### PR TITLE
add `defer` attribute to `<script>` tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>To-do</title>
     <link rel="stylesheet" href="css/styles.css">
-    <script src="js/scripts.js"></script>
+    <script src="js/scripts.js" defer></script>
 </head>
 <body>
     


### PR DESCRIPTION
Adding a `defer` attribute to the `<script>` tag to prevent unload `DOM` elements by loading the script after html complete loading